### PR TITLE
feat: support finnhub api key

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -546,9 +546,11 @@
                             </select>
                             <input type="text" class="form-control" id="backend_url" name="backend_url" 
                                    placeholder="Backend URL" value="https://api.openai.com/v1" style="margin-top: 12px;">
-                            <input type="password" class="form-control" id="api_key" name="api_key" 
+                           <input type="password" class="form-control" id="api_key" name="api_key"
                                    placeholder="API Key (required)" required style="margin-top: 12px;">
-                            <div class="form-text text-warning" style="margin-top: 6px;">
+                           <input type="password" class="form-control" id="finnhub_api_key" name="finnhub_api_key"
+                                   placeholder="Finnhub API Key" style="margin-top: 12px;">
+                           <div class="form-text text-warning" style="margin-top: 6px;">
                                 <i class="fas fa-exclamation-triangle"></i>
                                 <strong>Security Notice:</strong> API key stored locally in browser.
                             </div>
@@ -631,6 +633,20 @@
                 localStorage.setItem('tradingAgentsCrypto_apiKey', apiKey);
             }
         }
+
+        function loadSavedFinnhubKey() {
+            const savedKey = localStorage.getItem('tradingAgentsCrypto_finnhubKey');
+            if (savedKey) {
+                document.getElementById('finnhub_api_key').value = savedKey;
+            }
+        }
+
+        function saveFinnhubKey() {
+            const key = document.getElementById('finnhub_api_key').value.trim();
+            if (key) {
+                localStorage.setItem('tradingAgentsCrypto_finnhubKey', key);
+            }
+        }
         
         function isValidApiKeyFormat(apiKey) {
             // Basic validation to prevent storing obviously invalid keys
@@ -661,15 +677,19 @@
             document.documentElement.setAttribute('data-theme', savedTheme);
         }
         
-        // Load saved API key on page load
+        // Load saved API keys on page load
         document.addEventListener('DOMContentLoaded', function() {
             loadSavedApiKey();
+            loadSavedFinnhubKey();
             loadSavedTheme();
         });
-        
-        // Save API key when user types
+
+        // Save API keys when user types
         document.getElementById('api_key').addEventListener('input', function() {
             saveApiKey();
+        });
+        document.getElementById('finnhub_api_key').addEventListener('input', function() {
+            saveFinnhubKey();
         });
         
         // Set default date to today
@@ -711,6 +731,7 @@
                 llm_provider: document.getElementById('llm_provider').value,
                 backend_url: document.getElementById('backend_url').value,
                 api_key: document.getElementById('api_key').value,
+                finnhub_api_key: document.getElementById('finnhub_api_key').value,
                 shallow_thinker: document.getElementById('shallow_thinker').value,
                 deep_thinker: document.getElementById('deep_thinker').value,
                 session_id: Date.now().toString()

--- a/tradingagents/dataflows/config.py
+++ b/tradingagents/dataflows/config.py
@@ -12,6 +12,7 @@ def initialize_config():
     if _config is None:
         _config = default_config.DEFAULT_CONFIG.copy()
         DATA_DIR = _config["data_dir"]
+        _config.setdefault("finnhub_api_key", "")
 
 
 def set_config(config: Dict):
@@ -20,6 +21,7 @@ def set_config(config: Dict):
     if _config is None:
         _config = default_config.DEFAULT_CONFIG.copy()
     _config.update(config)
+    _config.setdefault("finnhub_api_key", "")
     DATA_DIR = _config["data_dir"]
 
 

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -19,4 +19,5 @@ DEFAULT_CONFIG = {
     "max_recur_limit": 100,
     # Tool settings
     "online_tools": True,
+    "finnhub_api_key": os.getenv("FINNHUB_API_KEY", ""),
 }

--- a/web_app.py
+++ b/web_app.py
@@ -157,7 +157,12 @@ def health_check():
 def start_analysis():
     data = request.json
     session_id = data.get('session_id', str(int(time.time())))
-    
+
+    finnhub_api_key = data.get('finnhub_api_key', '')
+    if finnhub_api_key:
+        os.environ['FINNHUB_API_KEY'] = finnhub_api_key
+    data['finnhub_api_key'] = finnhub_api_key
+
     # Store analysis configuration
     analysis_sessions[session_id] = {
         'config': data,
@@ -195,8 +200,14 @@ def run_analysis_background(session_id: str, config: Dict):
             'shallow_thinker': config['shallow_thinker'],
             'deep_thinker': config['deep_thinker'],
             'research_depth': config['research_depth'],
-            'session_id': session_id  # Add session ID for unique memory collections
+            'session_id': session_id,  # Add session ID for unique memory collections
+            'finnhub_api_key': config.get('finnhub_api_key', '')
         })
+
+        if updated_config.get('finnhub_api_key'):
+            os.environ['FINNHUB_API_KEY'] = updated_config['finnhub_api_key']
+        else:
+            updated_config['finnhub_api_key'] = os.environ.get('FINNHUB_API_KEY', '')
         
         if not is_production():
             print(f"[DEBUG] LLM provider: {updated_config['llm_provider']}")


### PR DESCRIPTION
## Summary
- add Finnhub API key input to web UI with localStorage persistence
- propagate Finnhub key through backend config and environment variables
- expose finnhub_api_key in default and dataflow configs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e2096425c8321aca42392a79eb0ad