### PR TITLE
feat: add multi-provider news search

### DIFF
--- a/tradingagents/agents/analysts/fundamentals_analyst.py
+++ b/tradingagents/agents/analysts/fundamentals_analyst.py
@@ -71,7 +71,7 @@ def create_fundamentals_analyst(llm, toolkit):
         else:
             # Use stock-specific tools (original functionality)
             if toolkit.config["online_tools"]:
-                tools = [toolkit.get_fundamentals_openai]
+                tools = [toolkit.get_fundamentals]
             else:
                 tools = [
                     toolkit.get_finnhub_company_insider_sentiment,

--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -71,7 +71,7 @@ def create_news_analyst(llm, toolkit):
         else:
             # Use stock-specific tools (original functionality)
             if toolkit.config["online_tools"]:
-                tools = [toolkit.get_global_news_openai, toolkit.get_google_news]
+                tools = [toolkit.get_global_news, toolkit.get_google_news]
             else:
                 tools = [
                     toolkit.get_finnhub_news,

--- a/tradingagents/agents/analysts/social_media_analyst.py
+++ b/tradingagents/agents/analysts/social_media_analyst.py
@@ -10,7 +10,7 @@ def create_social_media_analyst(llm, toolkit):
         company_name = state["company_of_interest"]
 
         if toolkit.config["online_tools"]:
-            tools = [toolkit.get_stock_news_openai]
+            tools = [toolkit.get_stock_news]
         else:
             tools = [
                 toolkit.get_reddit_stock_info,

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -363,60 +363,78 @@ class Toolkit:
 
     @staticmethod
     @tool
-    def get_stock_news_openai(
+    def get_stock_news(
         ticker: Annotated[str, "the company's ticker"],
         curr_date: Annotated[str, "Current date in yyyy-mm-dd format"],
+        llm_provider: Annotated[
+            str,
+            "LLM provider to use, e.g. 'openai' or 'google'",
+        ] = None,
     ):
         """
-        Retrieve the latest news about a given stock by using OpenAI's news API.
+        Retrieve the latest news about a given stock using the selected LLM provider.
         Args:
             ticker (str): Ticker of a company. e.g. AAPL, TSM
             curr_date (str): Current date in yyyy-mm-dd format
+            llm_provider (str): Which LLM provider to use; defaults to config
         Returns:
             str: A formatted string containing the latest news about the company on the given date.
         """
 
-        openai_news_results = interface.get_stock_news_openai(ticker, curr_date)
+        provider = llm_provider or Toolkit._config["llm_provider"]
+        news_results = interface.get_stock_news(ticker, curr_date, provider)
 
-        return openai_news_results
+        return news_results
 
     @staticmethod
     @tool
-    def get_global_news_openai(
+    def get_global_news(
         curr_date: Annotated[str, "Current date in yyyy-mm-dd format"],
+        llm_provider: Annotated[
+            str,
+            "LLM provider to use, e.g. 'openai' or 'google'",
+        ] = None,
     ):
         """
-        Retrieve the latest macroeconomics news on a given date using OpenAI's macroeconomics news API.
+        Retrieve the latest macroeconomics news on a given date using the selected LLM provider.
         Args:
             curr_date (str): Current date in yyyy-mm-dd format
+            llm_provider (str): Which LLM provider to use; defaults to config
         Returns:
             str: A formatted string containing the latest macroeconomic news on the given date.
         """
 
-        openai_news_results = interface.get_global_news_openai(curr_date)
+        provider = llm_provider or Toolkit._config["llm_provider"]
+        news_results = interface.get_global_news(curr_date, provider)
 
-        return openai_news_results
+        return news_results
 
     @staticmethod
     @tool
-    def get_fundamentals_openai(
+    def get_fundamentals(
         ticker: Annotated[str, "the company's ticker"],
         curr_date: Annotated[str, "Current date in yyyy-mm-dd format"],
+        llm_provider: Annotated[
+            str,
+            "LLM provider to use, e.g. 'openai' or 'google'",
+        ] = None,
     ):
         """
-        Retrieve the latest fundamental information about a given stock on a given date by using OpenAI's news API.
+        Retrieve the latest fundamental information about a given stock on a given date using the selected LLM provider.
         Args:
             ticker (str): Ticker of a company. e.g. AAPL, TSM
             curr_date (str): Current date in yyyy-mm-dd format
+            llm_provider (str): Which LLM provider to use; defaults to config
         Returns:
             str: A formatted string containing the latest fundamental information about the company on the given date.
         """
 
-        openai_fundamentals_results = interface.get_fundamentals_openai(
-            ticker, curr_date
+        provider = llm_provider or Toolkit._config["llm_provider"]
+        fundamentals_results = interface.get_fundamentals(
+            ticker, curr_date, provider
         )
 
-        return openai_fundamentals_results
+        return fundamentals_results
 
     # ===== CRYPTO TRADING TOOLS =====
 

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -151,7 +151,7 @@ class TradingAgentsGraph:
             "social": ToolNode(
                 [
                     # Stock tools (online)
-                    self.toolkit.get_stock_news_openai,
+                    self.toolkit.get_stock_news,
                     # Stock tools (offline)
                     self.toolkit.get_reddit_stock_info,
                     # Crypto tools
@@ -161,7 +161,7 @@ class TradingAgentsGraph:
             "news": ToolNode(
                 [
                     # Stock tools (online)
-                    self.toolkit.get_global_news_openai,
+                    self.toolkit.get_global_news,
                     self.toolkit.get_google_news,
                     # Stock tools (offline)
                     self.toolkit.get_finnhub_news,
@@ -173,7 +173,7 @@ class TradingAgentsGraph:
             "fundamentals": ToolNode(
                 [
                     # Stock tools (online)
-                    self.toolkit.get_fundamentals_openai,
+                    self.toolkit.get_fundamentals,
                     # Stock tools (offline)
                     self.toolkit.get_finnhub_company_insider_sentiment,
                     self.toolkit.get_finnhub_company_insider_transactions,


### PR DESCRIPTION
## Summary
- add Google/Gemini news search implementations and provider selection
- route Toolkit and analyst tools through generic search functions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e324432a88321b4b9bd22905faa7e