### PR TITLE
feat: add LLM-aware news wrappers

### DIFF
--- a/tradingagents/agents/analysts/fundamentals_analyst.py
+++ b/tradingagents/agents/analysts/fundamentals_analyst.py
@@ -70,7 +70,9 @@ def create_fundamentals_analyst(llm, toolkit):
             )
         else:
             # Use stock-specific tools (original functionality)
-            if toolkit.config["online_tools"]:
+            provider = toolkit.config.get("llm_provider", "openai").lower()
+
+            if toolkit.config["online_tools"] and provider in ["openai", "google", "gemini"]:
                 tools = [toolkit.get_fundamentals]
             else:
                 tools = [

--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -70,7 +70,9 @@ def create_news_analyst(llm, toolkit):
             )
         else:
             # Use stock-specific tools (original functionality)
-            if toolkit.config["online_tools"]:
+            provider = toolkit.config.get("llm_provider", "openai").lower()
+
+            if toolkit.config["online_tools"] and provider in ["openai", "google", "gemini"]:
                 tools = [toolkit.get_global_news, toolkit.get_google_news]
             else:
                 tools = [

--- a/tradingagents/agents/analysts/social_media_analyst.py
+++ b/tradingagents/agents/analysts/social_media_analyst.py
@@ -9,7 +9,9 @@ def create_social_media_analyst(llm, toolkit):
         ticker = state["company_of_interest"]
         company_name = state["company_of_interest"]
 
-        if toolkit.config["online_tools"]:
+        provider = toolkit.config.get("llm_provider", "openai").lower()
+
+        if toolkit.config["online_tools"] and provider in ["openai", "google", "gemini"]:
             tools = [toolkit.get_stock_news]
         else:
             tools = [

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -361,9 +361,9 @@ class Toolkit:
 
         return google_news_results
 
-    @staticmethod
     @tool
     def get_stock_news(
+        self,
         ticker: Annotated[str, "the company's ticker"],
         curr_date: Annotated[str, "Current date in yyyy-mm-dd format"],
         llm_provider: Annotated[
@@ -381,14 +381,14 @@ class Toolkit:
             str: A formatted string containing the latest news about the company on the given date.
         """
 
-        provider = llm_provider or Toolkit._config["llm_provider"]
+        provider = llm_provider or self.config["llm_provider"]
         news_results = interface.get_stock_news(ticker, curr_date, provider)
 
         return news_results
 
-    @staticmethod
     @tool
     def get_global_news(
+        self,
         curr_date: Annotated[str, "Current date in yyyy-mm-dd format"],
         llm_provider: Annotated[
             str,
@@ -404,14 +404,14 @@ class Toolkit:
             str: A formatted string containing the latest macroeconomic news on the given date.
         """
 
-        provider = llm_provider or Toolkit._config["llm_provider"]
+        provider = llm_provider or self.config["llm_provider"]
         news_results = interface.get_global_news(curr_date, provider)
 
         return news_results
 
-    @staticmethod
     @tool
     def get_fundamentals(
+        self,
         ticker: Annotated[str, "the company's ticker"],
         curr_date: Annotated[str, "Current date in yyyy-mm-dd format"],
         llm_provider: Annotated[
@@ -429,7 +429,7 @@ class Toolkit:
             str: A formatted string containing the latest fundamental information about the company on the given date.
         """
 
-        provider = llm_provider or Toolkit._config["llm_provider"]
+        provider = llm_provider or self.config["llm_provider"]
         fundamentals_results = interface.get_fundamentals(
             ticker, curr_date, provider
         )


### PR DESCRIPTION
## Summary
- add provider-aware wrappers for stock, global news and fundamentals
- switch analysts to use provider-specific tools based on configured LLM provider

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e3932549c8321bcd03109778229cd