### PR TITLE
feat: add provider-specific tool nodes

### DIFF
--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -436,6 +436,64 @@ class Toolkit:
 
         return fundamentals_results
 
+    @tool
+    def get_stock_news_openai(
+        self,
+        ticker: Annotated[str, "the company's ticker"],
+        curr_date: Annotated[str, "Current date in yyyy-mm-dd format"],
+    ) -> str:
+        """Retrieve the latest stock news using OpenAI provider."""
+
+        return interface.get_stock_news_openai(ticker, curr_date)
+
+    @tool
+    def get_stock_news_google(
+        self,
+        ticker: Annotated[str, "the company's ticker"],
+        curr_date: Annotated[str, "Current date in yyyy-mm-dd format"],
+    ) -> str:
+        """Retrieve the latest stock news using Google/Gemini provider."""
+
+        return interface.get_stock_news_google(ticker, curr_date)
+
+    @tool
+    def get_global_news_openai(
+        self,
+        curr_date: Annotated[str, "Current date in yyyy-mm-dd format"],
+    ) -> str:
+        """Retrieve macroeconomic news using OpenAI provider."""
+
+        return interface.get_global_news_openai(curr_date)
+
+    @tool
+    def get_global_news_google(
+        self,
+        curr_date: Annotated[str, "Current date in yyyy-mm-dd format"],
+    ) -> str:
+        """Retrieve macroeconomic news using Google/Gemini provider."""
+
+        return interface.get_global_news_google(curr_date)
+
+    @tool
+    def get_fundamentals_openai(
+        self,
+        ticker: Annotated[str, "the company's ticker"],
+        curr_date: Annotated[str, "Current date in yyyy-mm-dd format"],
+    ) -> str:
+        """Retrieve stock fundamentals using OpenAI provider."""
+
+        return interface.get_fundamentals_openai(ticker, curr_date)
+
+    @tool
+    def get_fundamentals_google(
+        self,
+        ticker: Annotated[str, "the company's ticker"],
+        curr_date: Annotated[str, "Current date in yyyy-mm-dd format"],
+    ) -> str:
+        """Retrieve stock fundamentals using Google/Gemini provider."""
+
+        return interface.get_fundamentals_google(ticker, curr_date)
+
     # ===== CRYPTO TRADING TOOLS =====
 
     @staticmethod

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -133,6 +133,25 @@ class TradingAgentsGraph:
 
     def _create_tool_nodes(self) -> Dict[str, ToolNode]:
         """Create tool nodes for different data sources."""
+        provider = self.config["llm_provider"].lower()
+        is_openai = provider in ["openai", "ollama", "openrouter"]
+
+        stock_news_tool = (
+            self.toolkit.get_stock_news_openai
+            if is_openai
+            else self.toolkit.get_stock_news_google
+        )
+        global_news_tool = (
+            self.toolkit.get_global_news_openai
+            if is_openai
+            else self.toolkit.get_global_news_google
+        )
+        fundamentals_tool = (
+            self.toolkit.get_fundamentals_openai
+            if is_openai
+            else self.toolkit.get_fundamentals_google
+        )
+
         return {
             "market": ToolNode(
                 [
@@ -151,7 +170,7 @@ class TradingAgentsGraph:
             "social": ToolNode(
                 [
                     # Stock tools (online)
-                    self.toolkit.get_stock_news,
+                    stock_news_tool,
                     # Stock tools (offline)
                     self.toolkit.get_reddit_stock_info,
                     # Crypto tools
@@ -161,7 +180,7 @@ class TradingAgentsGraph:
             "news": ToolNode(
                 [
                     # Stock tools (online)
-                    self.toolkit.get_global_news,
+                    global_news_tool,
                     self.toolkit.get_google_news,
                     # Stock tools (offline)
                     self.toolkit.get_finnhub_news,
@@ -173,7 +192,7 @@ class TradingAgentsGraph:
             "fundamentals": ToolNode(
                 [
                     # Stock tools (online)
-                    self.toolkit.get_fundamentals,
+                    fundamentals_tool,
                     # Stock tools (offline)
                     self.toolkit.get_finnhub_company_insider_sentiment,
                     self.toolkit.get_finnhub_company_insider_transactions,


### PR DESCRIPTION
## Summary
- add OpenAI and Google/Gemini specific toolkit functions
- choose tool functions based on llm_provider in TradingAgentsGraph

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e3ada3c4c8321b266595d82040123