### PR TITLE
refactor: adopt BaseChatModel abstraction

### DIFF
--- a/tradingagents/agents/utils/agent_states.py
+++ b/tradingagents/agents/utils/agent_states.py
@@ -1,7 +1,6 @@
 from typing import Annotated, Sequence
 from datetime import date, timedelta, datetime
 from typing_extensions import TypedDict, Optional
-from langchain_openai import ChatOpenAI
 from tradingagents.agents import *
 from langgraph.prebuilt import ToolNode
 from langgraph.graph import END, StateGraph, START, MessagesState

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -9,7 +9,6 @@ import functools
 import pandas as pd
 import os
 from dateutil.relativedelta import relativedelta
-from langchain_openai import ChatOpenAI
 import tradingagents.dataflows.interface as interface
 from tradingagents.default_config import DEFAULT_CONFIG
 from langchain_core.messages import HumanMessage

--- a/tradingagents/graph/reflection.py
+++ b/tradingagents/graph/reflection.py
@@ -1,13 +1,13 @@
 # TradingAgents/graph/reflection.py
 
 from typing import Dict, Any
-from langchain_openai import ChatOpenAI
+from langchain_core.language_models.chat_models import BaseChatModel
 
 
 class Reflector:
     """Handles reflection on decisions and updating memory."""
 
-    def __init__(self, quick_thinking_llm: ChatOpenAI):
+    def __init__(self, quick_thinking_llm: BaseChatModel):
         """Initialize the reflector with an LLM."""
         self.quick_thinking_llm = quick_thinking_llm
         self.reflection_system_prompt = self._get_reflection_prompt()

--- a/tradingagents/graph/setup.py
+++ b/tradingagents/graph/setup.py
@@ -1,7 +1,7 @@
 # TradingAgents/graph/setup.py
 
 from typing import Dict, Any
-from langchain_openai import ChatOpenAI
+from langchain_core.language_models.chat_models import BaseChatModel
 from langgraph.graph import END, StateGraph, START
 from langgraph.prebuilt import ToolNode
 
@@ -17,8 +17,8 @@ class GraphSetup:
 
     def __init__(
         self,
-        quick_thinking_llm: ChatOpenAI,
-        deep_thinking_llm: ChatOpenAI,
+        quick_thinking_llm: BaseChatModel,
+        deep_thinking_llm: BaseChatModel,
         toolkit: Toolkit,
         tool_nodes: Dict[str, ToolNode],
         bull_memory,

--- a/tradingagents/graph/signal_processing.py
+++ b/tradingagents/graph/signal_processing.py
@@ -1,12 +1,12 @@
 # TradingAgents/graph/signal_processing.py
 
-from langchain_openai import ChatOpenAI
+from langchain_core.language_models.chat_models import BaseChatModel
 
 
 class SignalProcessor:
     """Processes trading signals to extract actionable decisions."""
 
-    def __init__(self, quick_thinking_llm: ChatOpenAI):
+    def __init__(self, quick_thinking_llm: BaseChatModel):
         """Initialize with an LLM for processing."""
         self.quick_thinking_llm = quick_thinking_llm
 

--- a/utils/translation.py
+++ b/utils/translation.py
@@ -8,6 +8,7 @@ from langchain_openai import ChatOpenAI
 from langchain_anthropic import ChatAnthropic
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_core.messages import SystemMessage, HumanMessage
+from langchain_core.language_models.chat_models import BaseChatModel
 
 ZH_SYSTEM_PROMPT = (
     "You are a professional financial translator. "
@@ -16,7 +17,7 @@ ZH_SYSTEM_PROMPT = (
 )
 
 
-def _create_llm_client(api_config: Dict):
+def _create_llm_client(api_config: Dict) -> BaseChatModel:
     """Create an LLM client based on the provider in ``api_config``."""
     provider = (api_config.get("llm_provider") or "openai").lower()
     model = api_config.get("quick_think_llm", "gpt-4o-mini")
@@ -41,7 +42,7 @@ def _create_llm_client(api_config: Dict):
     raise ValueError(f"Unsupported LLM provider: {provider}")
 
 
-def _invoke_client(client, text: str) -> str:
+def _invoke_client(client: BaseChatModel, text: str) -> str:
     """Send translation prompt to the LLM client and return response text."""
     messages = [
         SystemMessage(content=ZH_SYSTEM_PROMPT),


### PR DESCRIPTION
## Summary
- refactor graph setup, reflection, and signal processing components to accept any `BaseChatModel`
- generalize translation utility to return/consume `BaseChatModel`
- remove stray `ChatOpenAI` imports in utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e3cde381083219b1aff8e7b245efc