### PR TITLE
Defer report translation until analysis finishes

### DIFF
--- a/simple_web.py
+++ b/simple_web.py
@@ -62,11 +62,13 @@ class SimpleMessageBuffer:
 
     def update_report_section(self, section_name, content):
         if section_name in self.report_sections:
-            translated = translate_to_zh(content, self.api_config)
-            self.report_sections[section_name] = {
-                "en": content,
-                "zh": translated,
-            }
+            self.report_sections[section_name] = {"en": content, "zh": None}
+
+    def finalize_reports(self):
+        for section, data in self.report_sections.items():
+            if data and not data.get("zh"):
+                translated = translate_to_zh(data["en"], self.api_config)
+                data["zh"] = translated
 
     def update_progress(self, progress, step):
         self.progress = progress
@@ -238,6 +240,7 @@ def run_analysis_background(session_id: str, config: Dict):
                     buffer.update_agent_status("Portfolio Manager", "completed")
                     buffer.update_progress(100, "Analysis completed!")
 
+        buffer.finalize_reports()
         buffer.update_progress(100, "Analysis completed successfully!")
         analysis_sessions[session_id]["status"] = "completed"
 


### PR DESCRIPTION
## Summary
- Store only English content during analysis and translate all report sections in one pass at the end.
- Add finalize_reports methods to WebMessageBuffer and SimpleMessageBuffer and call them after analysis completes.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e3f9d7d3883218f7c74116eae5355