### PR TITLE
切換預設 LLM 為 Anthropic 模型

### DIFF
--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -9,10 +9,10 @@ DEFAULT_CONFIG = {
         "dataflows/data_cache",
     ),
     # LLM settings
-    "llm_provider": "openai",
-    "deep_think_llm": "o4-mini",
-    "quick_think_llm": "gpt-4o-mini",
-    "backend_url": "https://api.openai.com/v1",
+    "llm_provider": "anthropic",
+    "deep_think_llm": "claude-3-sonnet-20240229",
+    "quick_think_llm": "claude-3-haiku-20240307",
+    "backend_url": "https://api.anthropic.com",
     # Debate and discussion settings
     "max_debate_rounds": 1,
     "max_risk_discuss_rounds": 1,


### PR DESCRIPTION
## Summary
- 使用 Anthropic 取代原本的 OpenAI 預設，改成 `claude-3-haiku-20240307` 與 `claude-3-sonnet-20240229`
- 更新 provider 與 backend URL 以符合 Anthropic API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e42264adc83218c8fa45155cae03c