### PR TITLE
feat: add embedding config

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ This fork adds comprehensive cryptocurrency trading capabilities to the original
 4. **Set up environment variables**
    ```bash
    export FINNHUB_API_KEY=your_finnhub_api_key
+   export EMBEDDING_PROVIDER=openai
+   export EMBEDDING_BACKEND_URL=https://api.openai.com/v1
+   export EMBEDDING_API_KEY=your_embedding_key
    # Note: LLM API keys are entered via the web interface
    ```
 
@@ -200,7 +203,10 @@ Analyst Team → Research Team → Trader → Risk Management → Portfolio Mana
 
 ### Environment Variables
 ```bash
-FINNHUB_API_KEY=your_finnhub_key      # Required for financial data
+FINNHUB_API_KEY=your_finnhub_key              # Required for financial data
+EMBEDDING_PROVIDER=openai                     # Embedding service provider (optional)
+EMBEDDING_BACKEND_URL=https://api.openai.com/v1  # Embedding API endpoint (optional)
+EMBEDDING_API_KEY=your_embedding_key          # Required if using embeddings
 ```
 
 ### LLM Configuration

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -13,6 +13,11 @@ DEFAULT_CONFIG = {
     "deep_think_llm": "claude-3-sonnet-20240229",
     "quick_think_llm": "claude-3-haiku-20240307",
     "backend_url": "https://api.anthropic.com",
+    "embedding_provider": os.getenv("EMBEDDING_PROVIDER", "openai"),
+    "embedding_backend_url": os.getenv(
+        "EMBEDDING_BACKEND_URL", "https://api.openai.com/v1"
+    ),
+    "embedding_api_key": os.getenv("EMBEDDING_API_KEY", ""),
     # Debate and discussion settings
     "max_debate_rounds": 1,
     "max_risk_discuss_rounds": 1,


### PR DESCRIPTION
## Summary
- support configurable embedding provider, backend URL, and API key through environment variables
- document embedding-related environment variables in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ed1193fa88321ba9629d9a8193c9d