### PR TITLE
在記憶體模組加入嵌入 API Key 檢查

### DIFF
--- a/tradingagents/agents/utils/memory.py
+++ b/tradingagents/agents/utils/memory.py
@@ -5,24 +5,28 @@ import logging
 
 class FinancialSituationMemory:
     def __init__(self, name, config):
+        api_key = config.get("embedding_api_key")
+        if not api_key:
+            raise RuntimeError("未設定 EMBEDDING_API_KEY，請於環境變數或設定檔提供。")
+
         provider = config["embedding_provider"]
         if provider == "openai":
             from openai import OpenAI
             self.client = OpenAI(
                 base_url=config["embedding_backend_url"],
-                api_key=config["embedding_api_key"],
+                api_key=api_key,
             )
             self.embedding = "text-embedding-3-small"
         elif provider == "anthropic":
             from anthropic import Anthropic
             self.client = Anthropic(
-                api_key=config["embedding_api_key"],
+                api_key=api_key,
                 base_url=config["embedding_backend_url"],
             )
             self.embedding = "claude-embed-1"  # 依實際可用 model 調整
         elif provider == "gemini":
             import google.generativeai as genai
-            genai.configure(api_key=config["embedding_api_key"])
+            genai.configure(api_key=api_key)
             self.client = genai  # 依該 SDK 的使用方式取得 embeddings
             self.embedding = "textembedding-gecko"  # 範例 model
         else:


### PR DESCRIPTION
## Summary
- 初始化 FinancialSituationMemory 時若缺少 EMBEDDING_API_KEY 立即報錯，避免執行到嵌入服務才失敗

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ee4aaf6c08321aadb2f1210b8abf7