### PR TITLE
feat: fallback to main key for openai embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This fork adds comprehensive cryptocurrency trading capabilities to the original
    export FINNHUB_API_KEY=your_finnhub_api_key
    export EMBEDDING_PROVIDER=openai
    export EMBEDDING_BACKEND_URL=https://api.openai.com/v1
-   export EMBEDDING_API_KEY=your_embedding_key
+   export EMBEDDING_API_KEY=your_embedding_key  # 若留空且提供者為 openai，會自動回退使用主模型 api_key
    # Note: LLM API keys are entered via the web interface
    ```
 
@@ -206,7 +206,7 @@ Analyst Team → Research Team → Trader → Risk Management → Portfolio Mana
 ```bash
 export FINNHUB_API_KEY=你的_finnhub_key
 export EMBEDDING_PROVIDER=openai
-export EMBEDDING_API_KEY=你的_api_key
+export EMBEDDING_API_KEY=你的_api_key  # 若留空且提供者為 openai，會自動回退使用主模型 api_key
 # 如需自訂端點可設定 EMBEDDING_BACKEND_URL
 ```
 
@@ -218,7 +218,7 @@ export EMBEDDING_API_KEY=你的_api_key
 | Anthropic | `anthropic`         | `https://api.anthropic.com`    |
 | Google Gemini | `google`        | `https://generativelanguage.googleapis.com/v1` |
 
-選擇提供者後，將 `EMBEDDING_API_KEY` 設為對應服務的 API 金鑰，並視需要調整 `EMBEDDING_BACKEND_URL`。
+選擇提供者後，將 `EMBEDDING_API_KEY` 設為對應服務的 API 金鑰，並視需要調整 `EMBEDDING_BACKEND_URL`。若提供者為 `openai` 且未設定 `EMBEDDING_API_KEY`，會自動回退使用主模型的 `api_key`。
 
 ## 🔧 Configuration
 

--- a/tradingagents/agents/utils/memory.py
+++ b/tradingagents/agents/utils/memory.py
@@ -5,11 +5,13 @@ import logging
 
 class FinancialSituationMemory:
     def __init__(self, name, config):
+        provider = config["embedding_provider"]
         api_key = config.get("embedding_api_key")
+        if not api_key and provider == "openai":
+            api_key = config.get("api_key")
         if not api_key:
             raise RuntimeError("未設定 EMBEDDING_API_KEY，請於環境變數或設定檔提供。")
 
-        provider = config["embedding_provider"]
         if provider == "openai":
             from openai import OpenAI
             self.client = OpenAI(

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -17,7 +17,7 @@ DEFAULT_CONFIG = {
     "embedding_backend_url": os.getenv(
         "EMBEDDING_BACKEND_URL", "https://api.openai.com/v1"
     ),
-    "embedding_api_key": os.getenv("EMBEDDING_API_KEY", ""),
+    "embedding_api_key": os.getenv("EMBEDDING_API_KEY", ""),  # 若 provider 為 openai 且此項空白，會回退使用 api_key
     # Debate and discussion settings
     "max_debate_rounds": 1,
     "max_risk_discuss_rounds": 1,


### PR DESCRIPTION
## Summary
- add fallback to `api_key` when OpenAI embedding key missing
- document OpenAI embedding API key fallback in README and default config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eeaf06db083219ce26872fc146a21