### PR TITLE
Add embedding API key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ This fork adds comprehensive cryptocurrency trading capabilities to the original
    export EMBEDDING_PROVIDER=openai
    export EMBEDDING_BACKEND_URL=https://api.openai.com/v1
    export EMBEDDING_API_KEY=your_embedding_key  # 若留空且提供者為 openai，會自動回退使用主模型 api_key
-   # Note: LLM API keys are entered via the web interface
+   # Note: LLM and embedding API keys can be entered via the web interface
    ```
 
 5. **Run the web application**
@@ -138,6 +138,7 @@ This fork adds comprehensive cryptocurrency trading capabilities to the original
    - Set research depth level (market conditions, DeFi analysis, etc.)
    - Configure LLM provider and models
    - Enter your API key
+   - Enter an embedding API key if using a separate key for embeddings
 
 2. **Start Analysis**
    - Click "Start Analysis" to begin

--- a/simple_web.py
+++ b/simple_web.py
@@ -93,6 +93,11 @@ def start_analysis():
     session_id = str(uuid.uuid4())
 
     # Store analysis configuration
+    embedding_api_key = data.get("embedding_api_key", "")
+    if embedding_api_key:
+        os.environ["EMBEDDING_API_KEY"] = embedding_api_key
+    data["embedding_api_key"] = embedding_api_key
+
     analysis_sessions[session_id] = {
         "config": data,
         "buffer": SimpleMessageBuffer(session_id, data),
@@ -142,8 +147,14 @@ def run_analysis_background(session_id: str, config: Dict):
                 "shallow_thinker": config["shallow_thinker"],
                 "deep_thinker": config["deep_thinker"],
                 "research_depth": config["research_depth"],
+                "embedding_api_key": config.get("embedding_api_key", ""),
             }
         )
+
+        if updated_config.get("embedding_api_key"):
+            os.environ["EMBEDDING_API_KEY"] = updated_config["embedding_api_key"]
+        else:
+            updated_config["embedding_api_key"] = os.environ.get("EMBEDDING_API_KEY", "")
 
         # Create initial state
         init_state = graph.propagator.create_initial_state(

--- a/templates/index.html
+++ b/templates/index.html
@@ -544,10 +544,12 @@
                                 <option value="anthropic">Anthropic</option>
                                 <option value="google">Google</option>
                             </select>
-                            <input type="text" class="form-control" id="backend_url" name="backend_url" 
+                           <input type="text" class="form-control" id="backend_url" name="backend_url"
                                    placeholder="Backend URL" value="https://api.openai.com/v1" style="margin-top: 12px;">
                            <input type="password" class="form-control" id="api_key" name="api_key"
                                    placeholder="API Key (required)" required style="margin-top: 12px;">
+                           <input type="password" class="form-control" id="embedding_api_key" name="embedding_api_key"
+                                   placeholder="Embedding API Key (optional)" style="margin-top: 12px;">
                            <input type="password" class="form-control" id="finnhub_api_key" name="finnhub_api_key"
                                    placeholder="Finnhub API Key" style="margin-top: 12px;">
                            <div class="form-text text-warning" style="margin-top: 6px;">
@@ -624,13 +626,27 @@
                 document.getElementById('api_key').value = savedApiKey;
             }
         }
-        
+
         function saveApiKey() {
             const apiKey = document.getElementById('api_key').value.trim();
             if (apiKey && isValidApiKeyFormat(apiKey)) {
                 // WARNING: This stores the API key in browser localStorage
                 // Only use this for development/testing purposes
                 localStorage.setItem('tradingAgentsCrypto_apiKey', apiKey);
+            }
+        }
+
+        function loadSavedEmbeddingKey() {
+            const savedKey = localStorage.getItem('tradingAgentsCrypto_embeddingKey');
+            if (savedKey && isValidApiKeyFormat(savedKey)) {
+                document.getElementById('embedding_api_key').value = savedKey;
+            }
+        }
+
+        function saveEmbeddingKey() {
+            const key = document.getElementById('embedding_api_key').value.trim();
+            if (key && isValidApiKeyFormat(key)) {
+                localStorage.setItem('tradingAgentsCrypto_embeddingKey', key);
             }
         }
 
@@ -681,6 +697,7 @@
         document.addEventListener('DOMContentLoaded', function() {
             loadSavedApiKey();
             loadSavedFinnhubKey();
+            loadSavedEmbeddingKey();
             loadSavedTheme();
         });
 
@@ -690,6 +707,9 @@
         });
         document.getElementById('finnhub_api_key').addEventListener('input', function() {
             saveFinnhubKey();
+        });
+        document.getElementById('embedding_api_key').addEventListener('input', function() {
+            saveEmbeddingKey();
         });
         
         // Set default date to today
@@ -731,6 +751,7 @@
                 llm_provider: document.getElementById('llm_provider').value,
                 backend_url: document.getElementById('backend_url').value,
                 api_key: document.getElementById('api_key').value,
+                embedding_api_key: document.getElementById('embedding_api_key').value,
                 finnhub_api_key: document.getElementById('finnhub_api_key').value,
                 shallow_thinker: document.getElementById('shallow_thinker').value,
                 deep_thinker: document.getElementById('deep_thinker').value,

--- a/web_app.py
+++ b/web_app.py
@@ -205,6 +205,11 @@ def start_analysis():
         os.environ["FINNHUB_API_KEY"] = finnhub_api_key
     data["finnhub_api_key"] = finnhub_api_key
 
+    embedding_api_key = data.get("embedding_api_key", "")
+    if embedding_api_key:
+        os.environ["EMBEDDING_API_KEY"] = embedding_api_key
+    data["embedding_api_key"] = embedding_api_key
+
     # Store analysis configuration
     analysis_sessions[session_id] = {
         "config": data,
@@ -239,6 +244,7 @@ def run_analysis_background(session_id: str, config: Dict):
                 "llm_provider": config["llm_provider"],
                 "backend_url": config["backend_url"],
                 "api_key": config.get("api_key", ""),
+                "embedding_api_key": config.get("embedding_api_key", ""),
                 "shallow_thinker": config["shallow_thinker"],
                 "deep_thinker": config["deep_thinker"],
                 "research_depth": config["research_depth"],
@@ -251,6 +257,11 @@ def run_analysis_background(session_id: str, config: Dict):
             os.environ["FINNHUB_API_KEY"] = updated_config["finnhub_api_key"]
         else:
             updated_config["finnhub_api_key"] = os.environ.get("FINNHUB_API_KEY", "")
+
+        if updated_config.get("embedding_api_key"):
+            os.environ["EMBEDDING_API_KEY"] = updated_config["embedding_api_key"]
+        else:
+            updated_config["embedding_api_key"] = os.environ.get("EMBEDDING_API_KEY", "")
 
         if not is_production():
             print(f"[DEBUG] LLM provider: {updated_config['llm_provider']}")

--- a/web_app_vercel.py
+++ b/web_app_vercel.py
@@ -82,6 +82,11 @@ def start_analysis():
     try:
         data = request.json
         session_id = data.get('session_id', str(int(time.time())))
+
+        embedding_api_key = data.get('embedding_api_key', '')
+        if embedding_api_key:
+            os.environ['EMBEDDING_API_KEY'] = embedding_api_key
+        data['embedding_api_key'] = embedding_api_key
         
         # Create a simplified response for Vercel environment
         buffer = SimpleMessageBuffer(session_id)


### PR DESCRIPTION
## Summary
- add optional `embedding_api_key` field to web UI and persist in local storage
- forward `embedding_api_key` to backend configuration
- document embedding API key usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688eec7af34883219844704f389443cc