### PR TITLE
refactor: remove embedding api key

### DIFF
--- a/tradingagents/agents/utils/memory.py
+++ b/tradingagents/agents/utils/memory.py
@@ -6,11 +6,9 @@ import logging
 class FinancialSituationMemory:
     def __init__(self, name, config):
         provider = config["embedding_provider"]
-        api_key = config.get("embedding_api_key")
-        if not api_key and provider == "openai":
-            api_key = config.get("api_key")
+        api_key = config["api_key"]
         if not api_key:
-            raise RuntimeError("未設定 EMBEDDING_API_KEY，請於環境變數或設定檔提供。")
+            raise RuntimeError("未設定 API_KEY，請於環境變數或設定檔提供。")
 
         if provider == "openai":
             from openai import OpenAI

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -17,7 +17,6 @@ DEFAULT_CONFIG = {
     "embedding_backend_url": os.getenv(
         "EMBEDDING_BACKEND_URL", "https://api.openai.com/v1"
     ),
-    "embedding_api_key": os.getenv("EMBEDDING_API_KEY", ""),  # 若 provider 為 openai 且此項空白，會回退使用 api_key
     # Debate and discussion settings
     "max_debate_rounds": 1,
     "max_risk_discuss_rounds": 1,


### PR DESCRIPTION
## Summary
- refactor memory initialization to rely solely on `api_key`
- clean up default config by removing obsolete `embedding_api_key`

## Testing
- `pre-commit run --files tradingagents/agents/utils/memory.py tradingagents/default_config.py` *(fails: command not found, unable to install `pre-commit`)*

------
https://chatgpt.com/codex/tasks/task_e_688efafbdb64832189b3f0d39c62dd07