### PR TITLE
refactor: remove embedding api key

### DIFF
--- a/simple_web.py
+++ b/simple_web.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import threading
 import time
+import os
 from pathlib import Path
 from typing import Dict, List, Optional
 import uuid
@@ -93,10 +94,6 @@ def start_analysis():
     session_id = str(uuid.uuid4())
 
     # Store analysis configuration
-    embedding_api_key = data.get("embedding_api_key", "")
-    if embedding_api_key:
-        os.environ["EMBEDDING_API_KEY"] = embedding_api_key
-    data["embedding_api_key"] = embedding_api_key
 
     analysis_sessions[session_id] = {
         "config": data,
@@ -144,17 +141,17 @@ def run_analysis_background(session_id: str, config: Dict):
             {
                 "llm_provider": config["llm_provider"],
                 "backend_url": config["backend_url"],
+                "api_key": config.get("api_key", ""),
                 "shallow_thinker": config["shallow_thinker"],
                 "deep_thinker": config["deep_thinker"],
                 "research_depth": config["research_depth"],
-                "embedding_api_key": config.get("embedding_api_key", ""),
             }
         )
 
-        if updated_config.get("embedding_api_key"):
-            os.environ["EMBEDDING_API_KEY"] = updated_config["embedding_api_key"]
+        if updated_config.get("api_key"):
+            os.environ["EMBEDDING_API_KEY"] = updated_config["api_key"]
         else:
-            updated_config["embedding_api_key"] = os.environ.get("EMBEDDING_API_KEY", "")
+            updated_config["api_key"] = os.environ.get("EMBEDDING_API_KEY", "")
 
         # Create initial state
         init_state = graph.propagator.create_initial_state(

--- a/web_app.py
+++ b/web_app.py
@@ -205,10 +205,6 @@ def start_analysis():
         os.environ["FINNHUB_API_KEY"] = finnhub_api_key
     data["finnhub_api_key"] = finnhub_api_key
 
-    embedding_api_key = data.get("embedding_api_key", "")
-    if embedding_api_key:
-        os.environ["EMBEDDING_API_KEY"] = embedding_api_key
-    data["embedding_api_key"] = embedding_api_key
 
     # Store analysis configuration
     analysis_sessions[session_id] = {
@@ -244,7 +240,6 @@ def run_analysis_background(session_id: str, config: Dict):
                 "llm_provider": config["llm_provider"],
                 "backend_url": config["backend_url"],
                 "api_key": config.get("api_key", ""),
-                "embedding_api_key": config.get("embedding_api_key", ""),
                 "shallow_thinker": config["shallow_thinker"],
                 "deep_thinker": config["deep_thinker"],
                 "research_depth": config["research_depth"],
@@ -258,10 +253,10 @@ def run_analysis_background(session_id: str, config: Dict):
         else:
             updated_config["finnhub_api_key"] = os.environ.get("FINNHUB_API_KEY", "")
 
-        if updated_config.get("embedding_api_key"):
-            os.environ["EMBEDDING_API_KEY"] = updated_config["embedding_api_key"]
+        if updated_config.get("api_key"):
+            os.environ["EMBEDDING_API_KEY"] = updated_config["api_key"]
         else:
-            updated_config["embedding_api_key"] = os.environ.get("EMBEDDING_API_KEY", "")
+            updated_config["api_key"] = os.environ.get("EMBEDDING_API_KEY", "")
 
         if not is_production():
             print(f"[DEBUG] LLM provider: {updated_config['llm_provider']}")

--- a/web_app_vercel.py
+++ b/web_app_vercel.py
@@ -4,7 +4,6 @@ import json
 import time
 from pathlib import Path
 from typing import Dict, List, Optional
-import os
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = 'tradingagents_secret_key'
@@ -83,10 +82,6 @@ def start_analysis():
         data = request.json
         session_id = data.get('session_id', str(int(time.time())))
 
-        embedding_api_key = data.get('embedding_api_key', '')
-        if embedding_api_key:
-            os.environ['EMBEDDING_API_KEY'] = embedding_api_key
-        data['embedding_api_key'] = embedding_api_key
         
         # Create a simplified response for Vercel environment
         buffer = SimpleMessageBuffer(session_id)


### PR DESCRIPTION
## Summary
- remove embedding API key handling from web_app, simple_web, and web_app_vercel
- unify configuration to use a single API key for both LLM and embeddings

## Testing
- `pre-commit run --files web_app.py simple_web.py web_app_vercel.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_688efda3f2cc8321a32aa928887d8d46